### PR TITLE
Pass correct workspaceFolder in configuration response

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -36,3 +36,4 @@ class LspEslintPlugin(NpmClientHandler):
                 for folder in session.get_workspace_folders():
                     if folder.includes_uri(scope_uri):
                         configuration['workspaceFolder'] = folder.to_lsp()
+                        break


### PR DESCRIPTION
The break in the loop was missing, causing us to send less relevant
workspace folder when there were multiple that matched the file URI.

The session folders are sorted longest-first so the first found is the
most relevant one.

Resolves #28