### PR TITLE
Add support for resolving workspaceDirectories

### DIFF
--- a/LSP-eslint.sublime-settings
+++ b/LSP-eslint.sublime-settings
@@ -35,12 +35,14 @@
 			"enable": true,
 			"mode": "all"
 		},
-		// Optional list of working directories.
+		// An optional list of working directories or a setting on how those are auto-resolved.
+		//
 		// This setting will normally only be set per-project to provide a list of working
-		// directories within that project that the server should consider as bases for resolving
-		// the eslint configuration.
+		// directories. The server will consider those as bases for resolving // the eslint configuration.
+		//
 		// Refer to the `eslint.workingDirectories` documentation at https://github.com/Microsoft/vscode-eslint
 		// for more info.
+		//
 		// NOTE that the `{ "pattern": glob pattern }` variant is not supported in LSP-eslint.
 		"workingDirectories": null
 	}

--- a/LSP-eslint.sublime-settings
+++ b/LSP-eslint.sublime-settings
@@ -35,5 +35,13 @@
 			"enable": true,
 			"mode": "all"
 		},
+		// Optional list of working directories.
+		// This setting will normally only be set per-project to provide a list of working
+		// directories within that project that the server should consider as bases for resolving
+		// the eslint configuration.
+		// Refer to the `eslint.workingDirectories` documentation at https://github.com/Microsoft/vscode-eslint
+		// for more info.
+		// NOTE that the `{ "pattern": glob pattern }` variant is not supported in LSP-eslint.
+		"workingDirectories": null
 	}
 }

--- a/README.md
+++ b/README.md
@@ -13,17 +13,13 @@ Open configuration file using command palette with `Preferences: LSP-eslint Sett
 
 Configuration file contains multiple configuration keys:
 
-#### scopes
+#### languages
 
-Defines which scopes ESLint can run in.
-
-#### syntaxes
-
-Defines which syntax files ESLint can run in.
+Defines on which types of files the ESLint server will run.
 
 #### settings
 
-ESLint configuration options. Refer to [documentation for VSCode extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).
+ESLint configuration options. Refer to [documentation for VSCode extension](https://github.com/Microsoft/vscode-eslint).
 
 ### FAQ
 

--- a/plugin.py
+++ b/plugin.py
@@ -1,6 +1,10 @@
 import os
+import posixpath
+import re
+import sublime
 import webbrowser
 
+from LSP.plugin.core.url import uri_to_filename
 from lsp_utils import NpmClientHandler
 
 
@@ -16,6 +20,14 @@ class LspEslintPlugin(NpmClientHandler):
     package_name = __package__
     server_directory = 'language-server'
     server_binary_path = os.path.join(server_directory, 'out', 'eslintServer.js')
+
+    @classmethod
+    def observe_file_changes(cls):
+        return [
+            '**/.eslintr{c.js,c.yaml,c.yml,c,c.json}',
+            '**/.eslintignore',
+            '**/package.json',
+        ]
 
     def on_ready(self, api) -> None:
         api.on_notification('eslint/status', self.handle_status)
@@ -33,7 +45,77 @@ class LspEslintPlugin(NpmClientHandler):
         if session:
             scope_uri = params.get('scopeUri')
             if scope_uri:
+                workspace_folder = None
                 for folder in session.get_workspace_folders():
                     if folder.includes_uri(scope_uri):
-                        configuration['workspaceFolder'] = folder.to_lsp()
+                        workspace_folder = folder
                         break
+                if workspace_folder:
+                    configuration['workspaceFolder'] = workspace_folder.to_lsp()
+                self.resolve_working_directory(configuration, scope_uri, workspace_folder)
+
+    def resolve_working_directory(self, configuration, scope_uri, workspace_folder) -> None:
+        working_directories = configuration.get('workingDirectories', None)
+        if isinstance(working_directories, list):
+            working_directory = None
+            workspace_folder_path = workspace_folder.path if workspace_folder else None
+            for entry in working_directories:
+                directory = None
+                no_cwd = False
+                if isinstance(entry, str):
+                    directory = entry
+                elif self.is_directory_item(entry):
+                    directory = entry.directory
+                    if isinstance(entry.get('!cwd', None), bool):
+                        no_cwd = entry['!cwd']
+                elif self.is_pattern_item(entry):
+                    print('LSP-eslint: workingDirectories configuration that uses "pattern" is not supported')
+                    pass
+                elif self.is_mode_item(entry):
+                    working_directory = entry
+                    continue
+
+                directory_value = None
+                if directory:
+                    file_path = uri_to_filename(scope_uri)
+                    if directory:
+                        directory = self.to_os_path(directory)
+                        if not os.path.isabs(directory) and workspace_folder_path:
+                            # Trailing '' will add trailing slash if missing.
+                            directory = os.path.join(workspace_folder_path, directory, '')
+                        if file_path.startswith(directory):
+                            directory_value = directory
+
+                if directory_value:
+                    if not working_directory or self.is_mode_item(working_directory):
+                        working_directory = { 'directory': directory_value, '!cwd': no_cwd }
+                    else:
+                        if len(working_directory['directory']) < len(directory_value):
+                            working_directory['directory'] = directory_value
+                            working_directory['!cwd'] = no_cwd
+            configuration['workingDirectory'] = working_directory
+
+    def is_directory_item(self, item) -> bool:
+        if isinstance(item, dict):
+            directory = item.get('directory', None)
+            not_cwd = item.get('!cwd', None)
+            return isinstance(directory, str) and (isinstance(not_cwd, bool) or not_cwd == None)
+        return False
+
+    def is_pattern_item(self, item) -> bool:
+        if isinstance(item, dict):
+            pattern = item.get('pattern', None)
+            not_cwd = item.get('!cwd', None)
+            return isinstance(pattern, str) and (isinstance(not_cwd, bool) or not_cwd == None)
+        return False
+
+    def is_mode_item(self, item) -> bool:
+        if isinstance(item, dict):
+            mode = item.get('mode', None)
+            return isinstance(mode, str) and mode in ('auto', 'location')
+        return False
+
+    def to_os_path(self, path) -> str:
+        if sublime.platform == 'windows':
+            path = re.sub(r'^\/(\w)\/', r'\1:\\', path)
+        return os.path.normpath(path);

--- a/plugin.py
+++ b/plugin.py
@@ -21,14 +21,6 @@ class LspEslintPlugin(NpmClientHandler):
     server_directory = 'language-server'
     server_binary_path = os.path.join(server_directory, 'out', 'eslintServer.js')
 
-    @classmethod
-    def observe_file_changes(cls):
-        return [
-            '**/.eslintr{c.js,c.yaml,c.yml,c,c.json}',
-            '**/.eslintignore',
-            '**/package.json',
-        ]
-
     def on_ready(self, api) -> None:
         api.on_notification('eslint/status', self.handle_status)
         api.on_request('eslint/openDoc', self.handle_open_doc)

--- a/plugin.py
+++ b/plugin.py
@@ -64,13 +64,13 @@ class LspEslintPlugin(NpmClientHandler):
                 no_cwd = False
                 if isinstance(entry, str):
                     directory = entry
-                elif self.is_directory_item(entry):
+                elif self.is_working_directory_item(entry, 'directory'):
                     directory = entry.directory
                     if isinstance(entry.get('!cwd', None), bool):
                         no_cwd = entry['!cwd']
-                elif self.is_pattern_item(entry):
+                elif self.is_working_directory_item(entry, 'pattern'):
                     print('LSP-eslint: workingDirectories configuration that uses "pattern" is not supported')
-                    pass
+                    continue
                 elif self.is_mode_item(entry):
                     working_directory = entry
                     continue
@@ -94,19 +94,13 @@ class LspEslintPlugin(NpmClientHandler):
                             working_directory['directory'] = directory_value
                             working_directory['!cwd'] = no_cwd
             configuration['workingDirectory'] = working_directory
+            configuration.pop('workingDirectories', None)
 
-    def is_directory_item(self, item) -> bool:
+    def is_working_directory_item(self, item, configuration_key) -> bool:
         if isinstance(item, dict):
-            directory = item.get('directory', None)
+            value = item.get(configuration_key, None)
             not_cwd = item.get('!cwd', None)
-            return isinstance(directory, str) and (isinstance(not_cwd, bool) or not_cwd == None)
-        return False
-
-    def is_pattern_item(self, item) -> bool:
-        if isinstance(item, dict):
-            pattern = item.get('pattern', None)
-            not_cwd = item.get('!cwd', None)
-            return isinstance(pattern, str) and (isinstance(not_cwd, bool) or not_cwd == None)
+            return isinstance(value, str) and (isinstance(not_cwd, bool) or not_cwd == None)
         return False
 
     def is_mode_item(self, item) -> bool:


### PR DESCRIPTION
Implements code for parsing user-supplied "workspaceDirectories" setting
into "workingDirectory" that server receives. The relevant code from
vscode-eslint extension is here:
https://github.com/microsoft/vscode-eslint/blob/a296a01afc79089c49a4f5c9c2b75831a03494b0/client/src/extension.ts#L1183-L1255

Configuring "workspaceDirectories" using patterns (rather than paths) is
not supported as there is some crazy parsing code that is required for
that and I didn't feel like converting that to python:
https://github.com/microsoft/vscode-eslint/blob/a296a01afc79089c49a4f5c9c2b75831a03494b0/client/src/utils.ts#L77-L228

Resolves #18