### PR TITLE
Fix: "workingDirectories" config using "directory"

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -100,7 +100,7 @@ class LspEslintPlugin(NpmClientHandler):
                 if isinstance(entry, str):
                     directory = entry
                 elif self.is_working_directory_item(entry, 'directory'):
-                    directory = entry.directory
+                    directory = entry.get('directory')
                     if isinstance(entry.get('!cwd', None), bool):
                         no_cwd = entry['!cwd']
                 elif self.is_working_directory_item(entry, 'pattern'):


### PR DESCRIPTION
There's an error when config workspace folder using `"workingDirectories": [{ directory: './packages' }]`, there's an error occurs: `AttributeError: 'dict' object has no attribute 'directory'`