### PR TITLE
feat: support Angular templates

### DIFF
--- a/LSP-eslint.sublime-settings
+++ b/LSP-eslint.sublime-settings
@@ -149,7 +149,7 @@
 		"${server_path}",
 		"--stdio"
 	],
-	"selector": "source.js | source.ts | source.jsx | source.tsx | source.js.jsx | source.js.react | source.ts.react | text.html.vue | text.html.basic",
+	"selector": "source.js | source.ts | source.jsx | source.tsx | source.js.jsx | source.js.react | source.ts.react | text.html.ngx | text.html.vue | text.html.basic",
 	"env": {
 		// Enables ESLint debug mode
 		// "DEBUG": "eslint:*,-eslint:code-path",


### PR DESCRIPTION
This PR adds support for Angular templates.

In Angular projects, we use [angular-eslint](https://github.com/angular-eslint/angular-eslint), which can also parse and lint Angular templates. When [LSP-angular](https://github.com/sublimelsp/LSP-angular) and [Ngx HTML](https://packages.sublimetext.io/packages/Ngx%20HTML) packages are installed, the file format becomes `text.html.ngx` which is currently missing from the selector